### PR TITLE
Add environment variable blocker for update function in main.go

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/signal"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -79,9 +80,13 @@ func main() {
 
 	// start periodic version checking
 	go func() {
-		for {
-			fetchLatestVersion()
-			time.Sleep(time.Hour * 3)
+		if disable, _ := strconv.ParseBool(os.Getenv("PYRAMID_DISABLE_UPDATE")); disable {
+			log.Warn().Msg("PYRAMID_DISABLE_UPDATE environment variable is set, auto-updater disabled")
+		} else {
+			for {
+				fetchLatestVersion()
+				time.Sleep(time.Hour * 3)
+			}
 		}
 	}()
 


### PR DESCRIPTION
This is a change to prepare for publishing Docker images.

I added an if/else statement that looks for an environment variable called `PYRAMID_DISABLE_UPDATE` that needs to be set to "true" or "1" to disable the auto-updater. If that is the case then Pyramid won't start the auto-update timer and a warning is logged to the console.