### PR TITLE
Fix merge of #27 overriding use of PYRAMID_DISABLE_UPDATE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     templ generate && \
     VERSION=$(git describe --tags --exact-match 2>/dev/null || echo "$(git describe --tags --abbrev=0)-$(git rev-parse --short=8 HEAD)") && \
-    CC=musl-gcc go build -tags=libsecp256k1 -ldflags="-X main.currentVersion=$VERSION -X main.autoUpdate=false -linkmode external -extldflags \"-static\"" -o ./pyramid-exe
+    CC=musl-gcc go build -tags=libsecp256k1 -ldflags="-X main.currentVersion=$VERSION -linkmode external -extldflags \"-static\"" -o ./pyramid-exe
 
 # Final image
 FROM ubuntu:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,5 +62,6 @@ COPY --from=builder /app/pyramid-exe ./pyramid-exe
 ENV HOST="0.0.0.0"
 ENV PORT="3334"
 ENV DATA_PATH="./data"
+ENV PYRAMID_DISABLE_UPDATE="true"
 
 CMD ["./pyramid-exe"]

--- a/main.go
+++ b/main.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"os/signal"
 	"slices"
-	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -78,15 +77,17 @@ func main() {
 	// stuff we have to initialize
 	fillInRelevantUsersMapping()
 
-	if autoUpdateEnabled() {
-		// start periodic version checking
-		go func() {
+	// start periodic version checking
+	go func() {
+		if !autoUpdateEnabled() {
+			log.Warn().Msg("PYRAMID_DISABLE_UPDATE environment variable is set, auto-updater disabled")
+		} else {
 			for {
 				fetchLatestVersion()
 				time.Sleep(time.Hour * 3)
 			}
-		}()
-	}
+		}
+	}()
 
 	// cleanup expired invite codes
 	go func() {

--- a/updates.go
+++ b/updates.go
@@ -10,6 +10,7 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -22,10 +23,6 @@ import (
 // this is set at build time to something else based on git
 var currentVersion string = "dev"
 
-// this is set at build time to false in Docker builds, where self-updating the
-// baked binary is not valid.
-var autoUpdate string = "true"
-
 // this is set by the user and reset on restart
 var customUpdateSource string
 
@@ -37,7 +34,10 @@ type releaseVersion struct {
 var latestVersion releaseVersion
 
 func autoUpdateEnabled() bool {
-	return !strings.EqualFold(autoUpdate, "false")
+	if disable, _ := strconv.ParseBool(os.Getenv("PYRAMID_DISABLE_UPDATE")); disable {
+		return false
+	}
+	return true
 }
 
 func fetchLatestVersion() {


### PR DESCRIPTION
This PR fixes the merge of #27 overwriting `main.go` check that was supposed to check `PYRAMID_DISABLE_UPDATE` for disabling auto updates