### PR TITLE
Add an option that allows group members to use Blossom

### DIFF
--- a/blossom/blossom.templ
+++ b/blossom/blossom.templ
@@ -2,6 +2,7 @@ package blossom
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 
 	"fiatjaf.com/nostr"
@@ -242,6 +243,8 @@ templ blossomPage(loggedUser nostr.PubKey) {
 							x-data={ `{
 								saved: false,
 								maxUserUploadSize: ` + global.JSONString(global.Settings.GetMaxUserUploadSizeDisplay()) + `,
+								allowGroupMembers: ` + strconv.FormatBool(global.Settings.Blossom.AllowGroupMembers) + `,
+								maxGroupMemberUploadSize: ` + strconv.Itoa(global.Settings.Blossom.MaxGroupMemberUploadSize) + `,
 								async saveSettings() {
 									const response = await fetch(this.$refs.form.action, {
 										method: 'POST',
@@ -269,6 +272,40 @@ templ blossomPage(loggedUser nostr.PubKey) {
 								/>
 								<p class="text-xs text-stone-500 dark:text-stone-400 mt-2">
 									use a single number (0 = unlimited) or slash-separated values per pyramid level (e.g. "100/50/25")
+								</p>
+							</div>
+							<div>
+								<label class="flex items-center cursor-pointer">
+									<input type="hidden" name="blossom_allow_group_members" :value="allowGroupMembers ? 'on' : 'off'"/>
+									<input
+										type="checkbox"
+										x-model="allowGroupMembers"
+										@change="saveSettings()"
+										class="rounded text-blue-500 focus:ring-blue-500"
+									/>
+									<span class="text-sm font-medium text-stone-700 dark:text-stone-300 ml-2">
+										allow members of any group to upload
+									</span>
+								</label>
+								<p class="text-xs text-stone-500 dark:text-stone-400 mt-2">
+									group members are not part of the pyramid; this lets anyone in a nip-29 group upload blobs
+								</p>
+							</div>
+							<div x-show="allowGroupMembers" x-transition>
+								<label for="blossom_max_group_member_upload_size" class="block text-sm font-medium text-stone-700 dark:text-stone-300 mb-2">
+									max total upload per group member (in megabytes)
+								</label>
+								<input
+									type="text"
+									id="blossom_max_group_member_upload_size"
+									name="blossom_max_group_member_upload_size"
+									x-model="maxGroupMemberUploadSize"
+									placeholder="e.g. 50"
+									@blur="saveSettings()"
+									class="w-full px-3 py-2 border border-stone-300 dark:border-stone-600 rounded-md bg-white dark:bg-stone-800 text-stone-900 dark:text-stone-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+								/>
+								<p class="text-xs text-stone-500 dark:text-stone-400 mt-2">
+									a single number (0 = unlimited)
 								</p>
 							</div>
 							<div

--- a/blossom/handler.go
+++ b/blossom/handler.go
@@ -14,6 +14,7 @@ import (
 	"fiatjaf.com/nostr/khatru/blossom"
 
 	"github.com/fiatjaf/pyramid/global"
+	"github.com/fiatjaf/pyramid/groups"
 	"github.com/fiatjaf/pyramid/pyramid"
 )
 
@@ -75,13 +76,22 @@ func setupEnabled() {
 		if auth == nil {
 			return true, "authentication required", 401
 		}
-		if !pyramid.IsMember(auth.PubKey) {
-			return true, "only pyramid members can upload blobs", 403
+		isMember := pyramid.IsMember(auth.PubKey)
+		isGroupMember := global.Settings.Blossom.AllowGroupMembers &&
+			groups.IsMemberOfAnyGroup(auth.PubKey)
+		if !isMember && !isGroupMember {
+			return true, "only pyramid or group members can upload blobs", 403
 		}
 
 		// check user upload size limit
 		if !pyramid.IsRoot(auth.PubKey) {
-			maxSize := pyramid.GetMaxBlossomUploadSizeFor(auth.PubKey) * 1024 * 1024
+			// Pyramid members use the tree based limit, group-only members use the flat group limit
+			var maxSize int
+			if isMember {
+				maxSize = pyramid.GetMaxBlossomUploadSizeFor(auth.PubKey) * 1024 * 1024
+			} else {
+				maxSize = global.Settings.Blossom.MaxGroupMemberUploadSize * 1024 * 1024
+			}
 			if maxSize > 0 {
 				if size > maxSize {
 					return true, "upload by itself exceeds user storage limit", 413

--- a/global/settings.go
+++ b/global/settings.go
@@ -112,6 +112,8 @@ type UserSettings struct {
 		Enabled                      bool  `json:"enabled"`
 		MaxUserUploadSize            int   `json:"max_user_upload_size,omitempty"` // in megabytes, 0 means unlimited
 		MaxUserUploadSizeAtEachLevel []int `json:"max_user_upload_size_at_each_level,omitempty"`
+		AllowGroupMembers            bool  `json:"allow_group_members,omitempty"`          // allow members of any nip-29 group to use blossom
+		MaxGroupMemberUploadSize     int   `json:"max_group_member_upload_size,omitempty"` // in megabytes, 0 means unlimited
 	} `json:"blossom"`
 
 	Nsite struct {
@@ -324,6 +326,9 @@ func loadUserSettings() error {
 	Settings.Popular.HTTPBasePath = "popular"
 	Settings.Uppermost.HTTPBasePath = "uppermost"
 	Settings.Moderated.HTTPBasePath = "moderated"
+
+	// Blossom settings
+	Settings.Blossom.MaxGroupMemberUploadSize = 1
 
 	// FTP settings
 	Settings.FTP.Enabled = false

--- a/groups/group.go
+++ b/groups/group.go
@@ -38,6 +38,19 @@ func (g *Group) AnyOfTheseIsAMember(pubkeys []nostr.PubKey) bool {
 	return false
 }
 
+// IsMemberOfAnyGroup returns whether the pubkey is a member of any group on this relay
+func IsMemberOfAnyGroup(pubkey nostr.PubKey) bool {
+	if State == nil {
+		return false
+	}
+	for _, group := range State.Groups.Range {
+		if group.AnyOfTheseIsAMember([]nostr.PubKey{pubkey}) {
+			return true
+		}
+	}
+	return false
+}
+
 func (g *Group) IsPrimaryRole(member nostr.PubKey) bool {
 	roles, _ := g.Members[member]
 	for _, role := range roles {

--- a/handler.go
+++ b/handler.go
@@ -551,6 +551,10 @@ func settingsHandler(w http.ResponseWriter, r *http.Request) {
 					global.Settings.Blossom.MaxUserUploadSize, _ = strconv.Atoi(v[0])
 					global.Settings.Blossom.MaxUserUploadSizeAtEachLevel = nil
 				}
+			case "blossom_allow_group_members":
+				global.Settings.Blossom.AllowGroupMembers = v[0] == "on"
+			case "blossom_max_group_member_upload_size":
+				global.Settings.Blossom.MaxGroupMemberUploadSize, _ = strconv.Atoi(v[0])
 			case "nsite_enabled":
 				global.Settings.Nsite.Enabled = v[0] == "on"
 				go restartSoon()


### PR DESCRIPTION
I added this feature in my dev fork of Pyramid to experiment with Squalk, feel free to ignore if it doesn't align with Pyramid's vision.