### PR TITLE
Add a Blossom option to delete blobs when their events are deleted

### DIFF
--- a/blossom/blossom.templ
+++ b/blossom/blossom.templ
@@ -245,6 +245,7 @@ templ blossomPage(loggedUser nostr.PubKey) {
 								maxUserUploadSize: ` + global.JSONString(global.Settings.GetMaxUserUploadSizeDisplay()) + `,
 								allowGroupMembers: ` + strconv.FormatBool(global.Settings.Blossom.AllowGroupMembers) + `,
 								maxGroupMemberUploadSize: ` + strconv.Itoa(global.Settings.Blossom.MaxGroupMemberUploadSize) + `,
+								reclaimOnEventDeletion: ` + strconv.FormatBool(global.Settings.Blossom.ReclaimOnEventDeletion) + `,
 								async saveSettings() {
 									const response = await fetch(this.$refs.form.action, {
 										method: 'POST',
@@ -306,6 +307,23 @@ templ blossomPage(loggedUser nostr.PubKey) {
 								/>
 								<p class="text-xs text-stone-500 dark:text-stone-400 mt-2">
 									a single number (0 = unlimited)
+								</p>
+							</div>
+							<div>
+								<label class="flex items-center cursor-pointer">
+									<input type="hidden" name="blossom_reclaim_on_event_deletion" :value="reclaimOnEventDeletion ? 'on' : 'off'"/>
+									<input
+										type="checkbox"
+										x-model="reclaimOnEventDeletion"
+										@change="saveSettings()"
+										class="rounded text-blue-500 focus:ring-blue-500"
+									/>
+									<span class="text-sm font-medium text-stone-700 dark:text-stone-300 ml-2">
+										delete blobs when their events are deleted
+									</span>
+								</label>
+								<p class="text-xs text-stone-500 dark:text-stone-400 mt-2">
+									when an event is deleted (by its author or by a group admin), any blob hosted here that it references is released and removed if no other event owns it
 								</p>
 							</div>
 							<div

--- a/blossom/handler.go
+++ b/blossom/handler.go
@@ -43,6 +43,8 @@ func Init(relay *khatru.Relay) {
 }
 
 func setupDisabled() {
+	global.ReclaimBlobsFromEvent = nil
+
 	Handler.mux = http.NewServeMux()
 	Handler.mux.HandleFunc("POST /blossom/enable", enableHandler)
 	Handler.mux.HandleFunc("GET /blossom/blobs", blobsPageHandler)
@@ -71,6 +73,8 @@ func setupEnabled() {
 		return file, nil, nil
 	}
 	Server.DeleteBlob = deleteBlob
+
+	global.ReclaimBlobsFromEvent = reclaimBlobsFromEvent
 
 	Server.RejectUpload = func(ctx context.Context, auth *nostr.Event, size int, ext string) (bool, string, int) {
 		if auth == nil {

--- a/blossom/reclaim.go
+++ b/blossom/reclaim.go
@@ -36,27 +36,27 @@ func reclaimBlobsFromEvent(ctx context.Context, id nostr.ID) {
 		return
 	}
 
-	// collect the text to scan: content plus every tag value
-	var sb strings.Builder
-	sb.WriteString(event.Content)
-	for _, tag := range event.Tags {
-		for _, v := range tag {
-			sb.WriteByte(' ')
-			sb.WriteString(v)
-		}
-	}
-
 	// match blob urls that point to this server: <domain>/<sha256>
 	re := regexp.MustCompile(regexp.QuoteMeta(domain) + `/([0-9a-f]{64})`)
 
-	seen := make(map[string]struct{})
-	for _, m := range re.FindAllStringSubmatch(sb.String(), -1) {
-		sha256 := m[1]
-		if _, ok := seen[sha256]; ok {
+	candidates := extractBlobs(re, event)
+	if len(candidates) == 0 {
+		return
+	}
+
+	// a blob stays if any other event by the same author still references it;
+	// ownership events (24242) live in the blossom layer, so scanning main by
+	// author only sees the author's real content events
+	for evt := range global.IL.Main.QueryEvents(nostr.Filter{Authors: []nostr.PubKey{event.PubKey}}, 100_000) {
+		if evt.ID == id {
 			continue
 		}
-		seen[sha256] = struct{}{}
+		for sha256 := range extractBlobs(re, evt) {
+			delete(candidates, sha256)
+		}
+	}
 
+	for sha256 := range candidates {
 		// remove the author's ownership link for this blob
 		if err := BlobIndex.Delete(ctx, sha256, event.PubKey); err != nil {
 			log.Warn().Err(err).Str("sha256", sha256).Msg("failed to release blob ownership on event deletion")
@@ -70,4 +70,23 @@ func reclaimBlobsFromEvent(ctx context.Context, id nostr.ID) {
 			}
 		}
 	}
+}
+
+// extractBlobs returns the set of blob sha256s referenced by an event, found in
+// its content or any tag value as a url pointing to this server.
+func extractBlobs(re *regexp.Regexp, event nostr.Event) map[string]struct{} {
+	var sb strings.Builder
+	sb.WriteString(event.Content)
+	for _, tag := range event.Tags {
+		for _, v := range tag {
+			sb.WriteByte(' ')
+			sb.WriteString(v)
+		}
+	}
+
+	blobs := make(map[string]struct{})
+	for _, m := range re.FindAllStringSubmatch(sb.String(), -1) {
+		blobs[m[1]] = struct{}{}
+	}
+	return blobs
 }

--- a/blossom/reclaim.go
+++ b/blossom/reclaim.go
@@ -1,0 +1,73 @@
+package blossom
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"fiatjaf.com/nostr"
+
+	"github.com/fiatjaf/pyramid/global"
+)
+
+// reclaimBlobsFromEvent scans an event that is about to be deleted for blobs
+// hosted on this server and releases the storage owned by the event's author.
+// The author is the uploader pyramid knows about, so this works whether the
+// deletion was triggered by the author (kind 5) or by a group admin (kind 9005).
+func reclaimBlobsFromEvent(ctx context.Context, id nostr.ID) {
+	if !global.Settings.Blossom.ReclaimOnEventDeletion {
+		return
+	}
+
+	domain := global.Settings.Domain
+	if domain == "" {
+		return
+	}
+
+	// fetch the event before it is removed so we can inspect its references
+	var event nostr.Event
+	found := false
+	for evt := range global.IL.Main.QueryEvents(nostr.Filter{IDs: []nostr.ID{id}}, 1) {
+		event = evt
+		found = true
+		break
+	}
+	if !found {
+		return
+	}
+
+	// collect the text to scan: content plus every tag value
+	var sb strings.Builder
+	sb.WriteString(event.Content)
+	for _, tag := range event.Tags {
+		for _, v := range tag {
+			sb.WriteByte(' ')
+			sb.WriteString(v)
+		}
+	}
+
+	// match blob urls that point to this server: <domain>/<sha256>
+	re := regexp.MustCompile(regexp.QuoteMeta(domain) + `/([0-9a-f]{64})`)
+
+	seen := make(map[string]struct{})
+	for _, m := range re.FindAllStringSubmatch(sb.String(), -1) {
+		sha256 := m[1]
+		if _, ok := seen[sha256]; ok {
+			continue
+		}
+		seen[sha256] = struct{}{}
+
+		// remove the author's ownership link for this blob
+		if err := BlobIndex.Delete(ctx, sha256, event.PubKey); err != nil {
+			log.Warn().Err(err).Str("sha256", sha256).Msg("failed to release blob ownership on event deletion")
+			continue
+		}
+
+		// physically remove the file only if nobody else owns it
+		if bd, _ := BlobIndex.Get(ctx, sha256); bd == nil {
+			if err := deleteBlob(ctx, sha256, ""); err != nil {
+				log.Warn().Err(err).Str("sha256", sha256).Msg("failed to delete orphaned blob file")
+			}
+		}
+	}
+}

--- a/global/global.go
+++ b/global/global.go
@@ -1,6 +1,7 @@
 package global
 
 import (
+	"context"
 	"embed"
 	"encoding/json"
 	"fmt"
@@ -253,3 +254,5 @@ var IL struct {
 	// operator registrations
 	OperatorBucket *mmm.IndexingLayer
 }
+
+var ReclaimBlobsFromEvent func(ctx context.Context, id nostr.ID)

--- a/global/settings.go
+++ b/global/settings.go
@@ -114,6 +114,7 @@ type UserSettings struct {
 		MaxUserUploadSizeAtEachLevel []int `json:"max_user_upload_size_at_each_level,omitempty"`
 		AllowGroupMembers            bool  `json:"allow_group_members,omitempty"`          // allow members of any nip-29 group to use blossom
 		MaxGroupMemberUploadSize     int   `json:"max_group_member_upload_size,omitempty"` // in megabytes, 0 means unlimited
+		ReclaimOnEventDeletion       bool  `json:"reclaim_on_event_deletion,omitempty"`    // delete blobs linked to an event when that event is deleted
 	} `json:"blossom"`
 
 	Nsite struct {

--- a/groups/process-event.go
+++ b/groups/process-event.go
@@ -66,6 +66,9 @@ func (s *GroupsState) ProcessEvent(ctx context.Context, event nostr.Event) (grou
 				if err != nil {
 					continue
 				}
+				if global.ReclaimBlobsFromEvent != nil {
+					global.ReclaimBlobsFromEvent(ctx, id)
+				}
 				if err := global.IL.Main.DeleteEvent(id); err != nil {
 					log.Warn().Err(err).Stringer("event", id).Msg("failed to delete")
 				} else {

--- a/handler.go
+++ b/handler.go
@@ -555,6 +555,8 @@ func settingsHandler(w http.ResponseWriter, r *http.Request) {
 				global.Settings.Blossom.AllowGroupMembers = v[0] == "on"
 			case "blossom_max_group_member_upload_size":
 				global.Settings.Blossom.MaxGroupMemberUploadSize, _ = strconv.Atoi(v[0])
+			case "blossom_reclaim_on_event_deletion":
+				global.Settings.Blossom.ReclaimOnEventDeletion = v[0] == "on"
 			case "nsite_enabled":
 				global.Settings.Nsite.Enabled = v[0] == "on"
 				go restartSoon()

--- a/main.go
+++ b/main.go
@@ -222,6 +222,11 @@ func main() {
 			}
 		}
 
+		// release blossom blobs linked to this event before it's gone
+		if global.ReclaimBlobsFromEvent != nil {
+			global.ReclaimBlobsFromEvent(ctx, id)
+		}
+
 		// try to delete from everywhere
 		if err := deleteFromMain(id); err != nil {
 			return err


### PR DESCRIPTION
Another feature from my dev fork of Pyramid to experiment with Squalk.
The idea is to introduce an automatism to keep the blossom storage as clean as possible, and to let an admin to moderate efficiently a message without leaving media around.