### PR TITLE
Fix panic in PubKeyFromInput on malformed nprofile input

### DIFF
--- a/global/utils.go
+++ b/global/utils.go
@@ -47,7 +47,7 @@ func PubKeyFromInput(input string) nostr.PubKey {
 	var pubkey nostr.PubKey
 	if pfx, value, err := nip19.Decode(input); err == nil && pfx == "npub" {
 		pubkey = value.(nostr.PubKey)
-	} else if pfx == "nprofile" {
+	} else if err == nil && pfx == "nprofile" {
 		pubkey = value.(nostr.ProfilePointer).PublicKey
 	} else if pk, err := nostr.PubKeyFromHex(input); err == nil {
 		pubkey = pk


### PR DESCRIPTION
The nprofile branch asserted the decoded value without checking the decode error, so a malformed nprofile (nip19.Decode returns a nil value with an error) panicked on the type assertion. Reachable from user input such as GET /blossom/u/{pubkey}. Check err before asserting.