### PR TITLE
Fix nil-error deref panics in operator handlers

### DIFF
--- a/operator/handler.go
+++ b/operator/handler.go
@@ -250,11 +250,11 @@ func handleRegister(w http.ResponseWriter, r *http.Request) {
 			"url":   {global.Settings.HTTPScheme() + global.Settings.Domain},
 		}.Encode()),
 	)
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	if err != nil {
 		http.Error(w, "failed to confirm with central: "+err.Error(), http.StatusBadGateway)
 		return
 	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("X-Pomegranate-Operator-Token", r.Header.Get("X-Pomegranate-Operator-Token"))
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/operator/sign.go
+++ b/operator/sign.go
@@ -54,7 +54,7 @@ func handleSign(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if reg.CentralPubKey != evt.PubKey.Hex() {
-		http.Error(w, err.Error(), http.StatusUnauthorized)
+		http.Error(w, "pubkey does not match registration", http.StatusUnauthorized)
 		return
 	}
 


### PR DESCRIPTION
handleSign called err.Error() on a guaranteed-nil err when the pubkey did not match the registration, and handleRegister set a header on req before checking the NewRequestWithContext error (req can be nil for an unparseable attacker-controlled central tag). Both panicked; use a static message and reorder the error check.