### PR TITLE
Add CI workflow running templ generate, build, vet and test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: install templ
+        run: go install github.com/a-h/templ/cmd/templ@v0.3.1020
+      - name: templ generate
+        run: templ generate
+      - name: build
+        run: go build ./...
+      - name: vet
+        run: go vet ./...
+      - name: test
+        run: go test ./...


### PR DESCRIPTION
No CI existed. Adds a GitHub Actions workflow on push to master and pull requests: installs templ v0.3.1020 (matching go.mod), runs templ generate (templ files are gitignored), then go build, vet and test.