### PR TITLE
Skip group moderation action when target group is nil

### DIFF
--- a/groups/process-event.go
+++ b/groups/process-event.go
@@ -51,8 +51,13 @@ func (s *GroupsState) ProcessEvent(ctx context.Context, event nostr.Event) (grou
 			hostRelay.BroadcastEvent(addCreator)
 		} else {
 			group = s.GetGroupFromEvent(event)
-			groupsAffected = nostr.AppendUnique(groupsAffected, group)
 		}
+
+		// the group may be unknown (e.g. concurrently deleted); skip if so
+		if group == nil {
+			return
+		}
+		groupsAffected = nostr.AppendUnique(groupsAffected, group)
 
 		// apply the moderation action
 		group.mu.Lock()


### PR DESCRIPTION
ProcessEvent locked group.mu without checking that GetGroupFromEvent returned a non-nil group (a concurrently deleted or unknown group), panicking on the nil deref. Return early when the group is nil.