### PR TITLE
Strip port from RemoteAddr when matching blocked IPs

### DIFF
--- a/ipblock.go
+++ b/ipblock.go
@@ -31,6 +31,10 @@ func ipBlockMiddleware(next http.Handler) http.Handler {
 				}
 			}
 			if ip := r.RemoteAddr; ip != "" {
+				// RemoteAddr is host:port, but blocked IPs are stored without a port
+				if host, _, err := net.SplitHostPort(ip); err == nil {
+					ip = host
+				}
 				if slices.Contains(global.Settings.BlockedIPs, ip) {
 					http.Error(w, "IP blocked", 403)
 					return


### PR DESCRIPTION
The blocked-IP middleware compared r.RemoteAddr (host:port) against the stored IPs, which have no port, so the RemoteAddr fallback never matched. Split the host off before comparing.