### PR TITLE
Fix swapped upload/download arguments in sync handler

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -1068,7 +1068,7 @@ func syncHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	streamingSync(r.Context(), targetUser, remoteUrl, download, upload, w)
+	streamingSync(r.Context(), targetUser, remoteUrl, upload, download, w)
 }
 
 func nip05Handler(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
syncHandler passed download and upload in the wrong order to streamingSync, so the fetch/publish directions were reversed. Pass upload then download to match the signature.