### PR TITLE
Reject malformed imgproxy tokens with 404 instead of proxying empty URL

### DIFF
--- a/imgproxy/handler.go
+++ b/imgproxy/handler.go
@@ -118,6 +118,10 @@ func pageHandler(w http.ResponseWriter, r *http.Request) {
 			}
 
 			imgproxyURL = "http://imgproxy/insecure" + path
+		} else {
+			// malformed token: reject instead of forwarding an empty URL
+			http.NotFound(w, r)
+			return
 		}
 
 		resp, err := imgproxySocketClient.Get(imgproxyURL)


### PR DESCRIPTION
When the token failed to decode or was not 48 bytes, imgproxyURL stayed empty and the request was still forwarded to the socket client, always returning 502. Reject malformed tokens with 404 before hitting the proxy.