### PR TITLE
Normalize host before resolving nsite so port and case do not break lookup

### DIFF
--- a/nsite/helpers.go
+++ b/nsite/helpers.go
@@ -2,6 +2,7 @@ package nsite
 
 import (
 	"fmt"
+	"net"
 	"strings"
 
 	"fiatjaf.com/nostr"
@@ -10,6 +11,13 @@ import (
 )
 
 func resolveSite(host string) (nostr.Event, error) {
+	// normalize the incoming host the same way the caller does before MatchesHost
+	host = strings.TrimSpace(host)
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+	host = strings.ToLower(host)
+
 	domain := strings.Trim(strings.ToLower(global.Settings.Nsite.Domain), ".")
 	if host == domain {
 		return nostr.Event{}, fmt.Errorf("domain mismatch")


### PR DESCRIPTION
resolveSite received the raw r.Host, so a non-standard port or mixed-case Host header made the suffix match fail and every nsite request 404. Strip the port and lowercase the host the same way the caller does before MatchesHost.