### PR TITLE
Apply only the new management action instead of replaying the whole log

### DIFF
--- a/pyramid/members.go
+++ b/pyramid/members.go
@@ -505,5 +505,9 @@ func appendActionToFile(action managementAction) error {
 		return err
 	}
 
-	return LoadManagement()
+	// apply only the new action: replaying the whole file here would
+	// re-apply all previous actions on top of the current state,
+	// duplicating parent links on every append
+	applyAction(action)
+	return nil
 }


### PR DESCRIPTION
appendActionToFile called LoadManagement, which re-reads and re-applies every past action on top of the live state without clearing it, so each append duplicated every member's parent links. Apply just the new action instead.