### PR TITLE
Remove duplicate operator registrations so erase deletes every shard

### DIFF
--- a/operator/model.go
+++ b/operator/model.go
@@ -27,6 +27,12 @@ func saveRegistration(reg Registration) error {
 		return err
 	}
 
+	// drop any previous registration(s) for this email so we don't leave
+	// duplicate shards behind (which a later erase/delete would miss)
+	if err := deleteRegistration(reg.Email); err != nil && err != ErrAccountNotFound {
+		return err
+	}
+
 	evt := nostr.Event{
 		Kind:      KindOperatorRegistrationStore,
 		Tags:      nostr.Tags{{"email", reg.Email}},
@@ -59,10 +65,18 @@ func loadRegistrationEvent(email string) (nostr.Event, Registration, error) {
 }
 
 func deleteRegistration(email string) error {
-	evt, _, err := loadRegistrationEvent(email)
-	if err != nil {
-		return err
+	found := false
+	for evt := range global.IL.OperatorBucket.QueryEvents(nostr.Filter{
+		Kinds: []nostr.Kind{KindOperatorRegistrationStore},
+		Tags:  nostr.TagMap{"email": []string{email}},
+	}, 100) {
+		found = true
+		if err := global.IL.OperatorBucket.DeleteEvent(evt.ID); err != nil {
+			return err
+		}
 	}
-
-	return global.IL.OperatorBucket.DeleteEvent(evt.ID)
+	if !found {
+		return ErrAccountNotFound
+	}
+	return nil
 }


### PR DESCRIPTION
saveRegistration always stored a new event and deleteRegistration removed only one, so re-registering left a second registration with its key shard that erase could not remove. Delete any prior registration for the email on save and delete all matches on erase.