### PR TITLE
Check secret store when deletion target not found in inbox

### DIFF
--- a/inbox/core.go
+++ b/inbox/core.go
@@ -94,7 +94,8 @@ func rejectEvent(ctx context.Context, evt nostr.Event) (bool, string) {
 					found = evt
 					break
 				}
-				if found.ID != nostr.ZeroID {
+				if found.ID == nostr.ZeroID {
+					// not in the inbox store, try the secret store too
 					for evt := range global.IL.Secret.QueryEvents(nostr.Filter{IDs: []nostr.ID{id}}, 1) {
 						found = evt
 						break


### PR DESCRIPTION
The kind-5 deletion check consulted the Secret store only when the target was already found in Inbox (inverted condition), so DMs stored in the Secret layer could never be deleted. Query the Secret store when the target is not in Inbox.