### PR TITLE
Update inbox allowed-kinds function instead of clobbering the main relay one

### DIFF
--- a/inbox/management.go
+++ b/inbox/management.go
@@ -198,7 +198,7 @@ func allowKindHandler(ctx context.Context, kind nostr.Kind) error {
 	}
 
 	// rebuild
-	global.KindIsAllowed, _ = global.BuildKindIsAllowedFunction(global.Settings.Inbox.AllowedKindsSpec, supportedKindsDefault)
+	kindIsAllowed, _ = global.BuildKindIsAllowedFunction(global.Settings.Inbox.AllowedKindsSpec, supportedKindsDefault)
 
 	return global.SaveUserSettings()
 }
@@ -249,7 +249,7 @@ func disallowKindHandler(ctx context.Context, kind nostr.Kind) error {
 	}
 
 	// rebuild this
-	global.KindIsAllowed, _ = global.BuildKindIsAllowedFunction(global.Settings.Inbox.AllowedKindsSpec, supportedKindsDefault)
+	kindIsAllowed, _ = global.BuildKindIsAllowedFunction(global.Settings.Inbox.AllowedKindsSpec, supportedKindsDefault)
 
 	return global.SaveUserSettings()
 }


### PR DESCRIPTION
allow/disallowKind rebuilt global.KindIsAllowed (the main relay function) from the inbox spec, breaking main and favorites kind filtering, while the inbox local function was left stale. Update the inbox-local function instead.