### PR TITLE
Enforce kind constraint in grasp ref validation and fix envconfig tag typo

### DIFF
--- a/global/global.go
+++ b/global/global.go
@@ -24,7 +24,7 @@ var assets embed.FS
 var (
 	S struct {
 		Port          string `envconfig:"PORT" default:"3334"`
-		SFTPPort      string `envconvig:"SFTP_PORT" default:"2222"`
+		SFTPPort      string `envconfig:"SFTP_PORT" default:"2222"`
 		Host          string `envconfig:"HOST" default:"localhost"`
 		DataPath      string `envconfig:"DATA_PATH" default:"./data"`
 		NoAutoUpdates bool   `envconfig:"NO_AUTO_UPDATES"`

--- a/grasp/validation.go
+++ b/grasp/validation.go
@@ -3,6 +3,7 @@ package grasp
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 
 	"fiatjaf.com/nostr"
@@ -77,11 +78,13 @@ func refExistsAsKind(eventId string, kinds []nostr.Kind) bool {
 		return false
 	}
 
-	for range global.IL.Main.QueryEvents(nostr.Filter{
-		IDs:   []nostr.ID{id},
-		Kinds: kinds,
+	// the ID query fast-path ignores the Kinds constraint, so check the kind ourselves
+	for evt := range global.IL.Main.QueryEvents(nostr.Filter{
+		IDs: []nostr.ID{id},
 	}, 1) {
-		return true
+		if slices.Contains(kinds, evt.Kind) {
+			return true
+		}
 	}
 
 	return false


### PR DESCRIPTION
refExistsAsKind relied on the ID query honoring Kinds, but the ID fast-path ignores it, so any existing event id passed validation. Check the kind explicitly. Also fix the SFTP_PORT envconfig struct tag typo.