### PR TITLE
Use max instead of min for curation vote thresholds

### DIFF
--- a/curation.go
+++ b/curation.go
@@ -54,8 +54,8 @@ func processReactions(ctx context.Context, event nostr.Event) {
 		}
 	}
 
-	popularThreshold := min(2, (totalMembers*global.Settings.Popular.PercentThreshold)/100)
-	uppermostThreshold := min(3, (totalMembers*global.Settings.Uppermost.PercentThreshold)/100)
+	popularThreshold := max(2, (totalMembers*global.Settings.Popular.PercentThreshold)/100)
+	uppermostThreshold := max(3, (totalMembers*global.Settings.Uppermost.PercentThreshold)/100)
 
 	// for all events we meet the popular threshold for
 	for target, votes := range popularVotes {


### PR DESCRIPTION
The popular and uppermost thresholds used min(2, ...) and min(3, ...), so the effective threshold collapsed to a tiny value and nearly everything was promoted. Use max so the percentage threshold acts as a floor of 2 and 3 votes.