### PR TITLE
Guard aggregated WoT behind an atomic pointer to avoid torn reads

### DIFF
--- a/inbox/core.go
+++ b/inbox/core.go
@@ -183,7 +183,7 @@ func rejectEvent(ctx context.Context, evt nostr.Event) (bool, string) {
 
 			for _, pk := range khatru.GetAllAuthed(ctx) {
 				// at least one authenticated pubkey is in the wot
-				if wot.Current.Contains(pk) {
+				if wot.Contains(pk) {
 					return false, ""
 				}
 			}
@@ -256,7 +256,7 @@ func rejectEvent(ctx context.Context, evt nostr.Event) (bool, string) {
 	}
 
 	// ensure this comes from someone in the relay combined extended network
-	if !wot.Current.Contains(sender) {
+	if !wot.Contains(sender) {
 		if evt.Kind == 9735 && sender == evt.PubKey {
 			// we'll make an exception for zap providers that do not include the "P" temporarily
 			return false, ""

--- a/inbox/inbox.templ
+++ b/inbox/inbox.templ
@@ -53,13 +53,13 @@ templ inboxPage(loggedUser nostr.PubKey) {
 					browse inbox →
 				</a>
 				<div class="mt-6 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-4">
-					if !wot.Computed {
+					if !wot.IsComputed() {
 						<span>calculating aggregated web-of-trust...</span>
 					} else {
 						<div class="flex items-center gap-4">
 							<h3 class="font-semibold text-gray-800 dark:text-gray-200">check who is allowed to post</h3>
 							<div class="text-sm text-gray-600 dark:text-gray-400">
-								{ fmt.Sprintf("(total: %d pubkeys)", wot.Current.Items) }
+								{ fmt.Sprintf("(total: %d pubkeys)", wot.Count()) }
 							</div>
 						</div>
 						<form

--- a/inbox/relay.go
+++ b/inbox/relay.go
@@ -237,5 +237,5 @@ func checkWoTHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	fmt.Fprintf(w, "%v", wot.Current.Contains(pk))
+	fmt.Fprintf(w, "%v", wot.Contains(pk))
 }

--- a/operator/handler.go
+++ b/operator/handler.go
@@ -211,11 +211,11 @@ func handleRegister(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	case "wot":
-		if !wot.Computed {
+		if !wot.IsComputed() {
 			http.Error(w, "web-of-trust not yet computed, try again later", http.StatusServiceUnavailable)
 			return
 		}
-		if !wot.Current.Contains(evt.PubKey) {
+		if !wot.Contains(evt.PubKey) {
 			http.Error(w, "only web-of-trust members can register", http.StatusForbidden)
 			return
 		}

--- a/wot/wot.go
+++ b/wot/wot.go
@@ -2,18 +2,46 @@ package wot
 
 import (
 	"context"
+	"sync/atomic"
 	"time"
 
+	"fiatjaf.com/nostr"
 	"github.com/fiatjaf/pyramid/global"
 )
 
-// Current is the latest computed aggregated web-of-trust filter.
-// It is safe to read at any time, even before it has been computed
-// (it will just return an empty filter that contains nothing).
-var Current XorFilter
+// current holds the latest computed aggregated web-of-trust filter.
+// it is stored behind an atomic pointer so it can be read from request
+// goroutines while the background goroutine replaces it, without racing
+// on the multi-word XorFilter struct.
+var current atomic.Pointer[XorFilter]
 
-// Computed is true after the first successful WoT computation.
-var Computed bool
+// computed is set to true after the first successful WoT computation.
+var computed atomic.Bool
+
+// Contains reports whether the given pubkey is in the latest aggregated WoT.
+// It is safe to call at any time, even before the first computation
+// (it will just return false).
+func Contains(pubkey nostr.PubKey) bool {
+	f := current.Load()
+	if f == nil {
+		return false
+	}
+	return f.Contains(pubkey)
+}
+
+// IsComputed reports whether the WoT has been computed at least once.
+func IsComputed() bool {
+	return computed.Load()
+}
+
+// Count returns the number of pubkeys in the latest aggregated WoT.
+func Count() int {
+	f := current.Load()
+	if f == nil {
+		return 0
+	}
+	return f.Items
+}
 
 // StartBackgroundComputation begins a periodic background loop that
 // recomputes the aggregated WoT every 48 hours. It sleeps 2 minutes
@@ -28,8 +56,8 @@ func StartBackgroundComputation() {
 				global.Log.Error().Err(err).Msg("failed to compute aggregated WoT")
 				time.Sleep(3 * time.Hour)
 			} else {
-				Current = wot
-				Computed = true
+				current.Store(&wot)
+				computed.Store(true)
 				global.Log.Info().Int("entries", wot.Items).Msg("computed aggregated WoT")
 				time.Sleep(48 * time.Hour)
 			}


### PR DESCRIPTION
The aggregated WoT filter was a plain global struct written by the background goroutine while request handlers read it, so a torn read of the slice header could panic or return wrong results. Store it behind an atomic pointer and expose Contains, IsComputed and Count accessors.