### PR TITLE
Fix log tail nil panic and leak and nil Request deref on listener removal

### DIFF
--- a/global/subscription_limits.go
+++ b/global/subscription_limits.go
@@ -73,7 +73,7 @@ func NewRelay() *khatru.Relay {
 	}
 
 	relay.OnListenerRemoved = func(ws *khatru.WebSocket, ssid int, id string, filter nostr.Filter) {
-		if ws == nil {
+		if ws == nil || ws.Request == nil {
 			return
 		}
 

--- a/global/utils.go
+++ b/global/utils.go
@@ -270,12 +270,20 @@ func LogHandler(w http.ResponseWriter, r *http.Request, logFile string) {
 	t, err := tail.TailFile(logFile, tail.Config{Follow: true, ReOpen: true})
 	if err != nil {
 		Log.Error().Err(err).Msg("failed to tail imgproxy.log")
+		return
 	}
+	defer t.Cleanup()
+	defer t.Stop()
 
-	for line := range t.Lines {
-		_, _ = io.WriteString(w, "<div class=\"line\">"+terminal.Render([]byte(line.Text))+"</div>\n")
-		flusher.Flush()
-		if r.Context().Err() != nil {
+	for {
+		select {
+		case line, ok := <-t.Lines:
+			if !ok {
+				return
+			}
+			_, _ = io.WriteString(w, "<div class=\"line\">"+terminal.Render([]byte(line.Text))+"</div>\n")
+			flusher.Flush()
+		case <-r.Context().Done():
 			return
 		}
 	}


### PR DESCRIPTION
LogHandler dereferenced a nil tail on TailFile error and leaked the tail on disconnect, and OnListenerRemoved passed a possibly nil Request to GetIPFromRequest. Return on tail error with cleanup, select on context done, and guard the nil Request.