### PR TITLE
Prevent panics on malformed SFTP paths and requests

### DIFF
--- a/ftp.go
+++ b/ftp.go
@@ -121,7 +121,7 @@ func handleSFTP(conn net.Conn, config *ssh.ServerConfig) {
 
 		go func(in <-chan *ssh.Request) {
 			for req := range in {
-				if req.Type == "subsystem" && string(req.Payload[4:]) == "sftp" {
+				if req.Type == "subsystem" && len(req.Payload) > 4 && string(req.Payload[4:]) == "sftp" {
 					req.Reply(true, nil)
 
 					server := sftp.NewRequestServer(channel, sftp.Handlers{
@@ -220,6 +220,9 @@ func (vfs SFTPVirtualFileSystem) Fileread(r *sftp.Request) (io.ReaderAt, error) 
 		// }
 
 		spl := strings.Split(path[2], ".")
+		if len(spl) < 2 {
+			return nil, os.ErrNotExist
+		}
 		hash := spl[0]
 		ext := "." + spl[1]
 
@@ -305,6 +308,9 @@ func (vfs SFTPVirtualFileSystem) Filecmd(r *sftp.Request) error {
 		switch path[0] {
 		case "blossom":
 			spl := strings.Split(path[2], ".")
+			if len(spl) < 2 {
+				return os.ErrNotExist
+			}
 			hash := spl[0]
 			ext := "." + spl[1]
 


### PR DESCRIPTION
SFTP handlers split filenames on dot and indexed element 1 without checking, and read the subsystem payload without a length check, both of which could panic. Guard the lengths.