### PR TITLE
Drop unused temp file leak in livekit binary download

### DIFF
--- a/groups/embedded_livekit.go
+++ b/groups/embedded_livekit.go
@@ -317,12 +317,6 @@ func ensureLiveKitBinary(release livekitRelease) error {
 	}
 
 	// download
-	out, err := os.CreateTemp(".", "livekit-archive-*")
-	if err != nil {
-		return fmt.Errorf("create livekit archive: %w", err)
-	}
-	defer out.Close()
-
 	resp, err := (&http.Client{Timeout: 60 * time.Second}).Get(assetURL)
 	if err != nil {
 		return fmt.Errorf("download livekit binary: %w", err)


### PR DESCRIPTION
ensureLiveKitBinary created a temp archive file that was never written and never removed. Remove it since the download streams straight into the tar reader.