### PR TITLE
Signal livekit exit before locking so immediate-exit detection works

### DIFF
--- a/groups/embedded_livekit.go
+++ b/groups/embedded_livekit.go
@@ -186,6 +186,11 @@ keys:
 	go func() {
 		err := cmd.Wait()
 
+		// signal the exit before taking the lock: StartEmbeddedLiveKit holds
+		// the mutex for its whole duration, so locking first would deadlock the
+		// "exited immediately" detection below
+		exited <- err
+
 		embeddedLiveKit.mu.Lock()
 		defer embeddedLiveKit.mu.Unlock()
 
@@ -197,7 +202,6 @@ keys:
 				log.Error().Err(err).Msg("embedded livekit server exited")
 			}
 		}
-		exited <- err
 	}()
 
 	select {


### PR DESCRIPTION
The Wait goroutine took the mutex that StartEmbeddedLiveKit holds for its whole duration before sending on the exited channel, so the immediate-exit detection could never fire. Send on the channel before acquiring the lock.