### PR TITLE
Close group search index before removing its directory

### DIFF
--- a/groups/search.go
+++ b/groups/search.go
@@ -155,13 +155,14 @@ func (group *Group) removeSearchIndex() error {
 		return nil
 	}
 
-	group.searchIndex = nil
-	group.language = lingua.Unknown
-	group.hasLanguage = false
-
+	// close the open index before nilling it out and removing its directory
 	if group.searchIndex != nil {
 		group.searchIndex.Close()
 	}
+
+	group.searchIndex = nil
+	group.language = lingua.Unknown
+	group.hasLanguage = false
 
 	if err := os.RemoveAll(groupSearchDir(group.Address.ID)); err != nil {
 		return fmt.Errorf("failed to remove group search directory: %w", err)


### PR DESCRIPTION
removeSearchIndex nilled searchIndex before the nil check, so Close was dead code and the bleve index directory was removed while still open. Close before nilling.