### PR TITLE
Skip saving group metadata event when signing fails

### DIFF
--- a/groups/group.go
+++ b/groups/group.go
@@ -206,6 +206,8 @@ func (s *GroupsState) SyncGroupMetadataEvents(group *Group) iter.Seq2[nostr.Even
 				if !yield(nostr.Event{}, fmt.Errorf("failed to sign group metadata event %d: %w", updated.Kind, err)) {
 					return
 				}
+				// don't save or broadcast an unsigned event
+				continue
 			}
 
 			if _, err := global.IL.Main.ReplaceEvent(updated); err != nil {


### PR DESCRIPTION
SyncGroupMetadataEvents still saved and could broadcast a group metadata event after Sign failed. Skip the event when signing fails.